### PR TITLE
IHandlerのUriをパラメーターで指定する

### DIFF
--- a/MoEmbed/Api.cs
+++ b/MoEmbed/Api.cs
@@ -24,7 +24,7 @@ namespace MoEmbed
             var url = queries["url"].ToString();
             if (string.IsNullOrEmpty(url))
             {
-                await context.Response.WriteAsync("{ error: 'No URL given' }");
+                await context.Response.WriteAsync("{ \"error\": \"No URL given\" }");
             }
             else
             {
@@ -39,7 +39,7 @@ namespace MoEmbed
                 }
                 catch (System.UriFormatException)
                 {
-                    json = "{ error: 'Invalid URL format. Please ensure you passed an URLEncoded URL.' }";
+                    json = "{ \"error\": \"Invalid URL format. Please ensure you passed an URLEncoded URL.\" }";
                 }
                 await context.Response.WriteAsync(json);
             }

--- a/MoEmbed/Api.cs
+++ b/MoEmbed/Api.cs
@@ -19,7 +19,6 @@ namespace MoEmbed
 
         public static async Task Embed(HttpContext context)
         {
-            Task res;
             var queries = context.Request.Query;
             var url = queries["url"].ToString();
             if (string.IsNullOrEmpty(url))

--- a/MoEmbed/Handlers/IHandler.cs
+++ b/MoEmbed/Handlers/IHandler.cs
@@ -6,10 +6,8 @@ namespace MoEmbed.Handlers
 {
     interface IHandler
     {
-        Uri Uri { get; set; }
-        void Init(Uri uri);
-        bool CanHandle();
-        EmbedObject GetEmbedObject();
+        bool CanHandle(Uri uri);
+        EmbedObject GetEmbedObject(Uri uri);
     }
 }
 

--- a/MoEmbed/Handlers/TwitterHandler.cs
+++ b/MoEmbed/Handlers/TwitterHandler.cs
@@ -8,34 +8,17 @@ namespace MoEmbed.Handlers
 {
     class TwitterHandler : IHandler
     {
-        public Uri Uri { get; set; }
-
-        public TwitterHandler(string uriString)
+        private static Regex regex = new Regex(@"https:\/\/twitter\.com\/[^\/]+\/status\/\d+");
+        
+        public bool CanHandle(Uri uri)
         {
-            var uri = new Uri(uriString);
-            this.Init(uri);
+            return regex.IsMatch(uri.ToString());
         }
 
-        public TwitterHandler(Uri uri)
-        {
-            this.Init(uri);
-        }
-
-        public void Init(Uri uri)
-        {
-            this.Uri = uri;
-        }
-
-        public bool CanHandle()
-        {
-            var regex = new Regex(@"https:\/\/twitter\.com\/[^\/]+\/status\/\d+");
-            return regex.IsMatch(this.Uri.ToString());
-        }
-
-        public EmbedObject GetEmbedObject()
+        public EmbedObject GetEmbedObject(Uri uri)
         {
             // TODO: implement this.
-            return new LinkEmbedObject(this.Uri);
+            return new LinkEmbedObject(uri);
         }
     }
 }


### PR DESCRIPTION
リクエスト毎にハンドラーを作成しなくてもよいようにUriをメソッド引数に変更。