### PR TITLE
JSON同様にXMLも出力できるようにする

### DIFF
--- a/MoEmbed/Models/IResponseWriter.cs
+++ b/MoEmbed/Models/IResponseWriter.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace MoEmbed.Models
+{
+    public interface IResponseWriter : IDisposable
+    {
+        void WriteStartResponse();
+        void WriteProperty(string name, bool value);
+        void WriteProperty(string name, double value);
+        void WriteProperty(string name, object value);
+        void WriteEndResponse();
+    }
+}

--- a/MoEmbed/Models/JsonResponseWriter.cs
+++ b/MoEmbed/Models/JsonResponseWriter.cs
@@ -1,0 +1,68 @@
+using System;
+using Newtonsoft.Json;
+
+namespace MoEmbed.Models
+{
+    public class JsonResponseWriter : IResponseWriter
+    {
+        private readonly bool _LeaveOpen;
+
+        public JsonResponseWriter(JsonWriter baseWriter, bool leaveOpen = false)
+        {
+            BaseWriter = baseWriter;
+            _LeaveOpen = leaveOpen;
+        }
+
+        protected JsonWriter BaseWriter { get; private set; }
+
+        public void WriteStartResponse()
+        {
+            ThrowIfDisposed();
+            BaseWriter.WriteStartObject();
+        }
+
+        public void WriteProperty(string name, bool value)
+        {
+            ThrowIfDisposed();
+            BaseWriter.WritePropertyName(name);
+            BaseWriter.WriteValue(value);
+        }
+
+        public void WriteProperty(string name, double value)
+        {
+            ThrowIfDisposed();
+            BaseWriter.WritePropertyName(name);
+            BaseWriter.WriteValue(value);
+        }
+        
+        public void WriteProperty(string name, object value)
+        {
+            ThrowIfDisposed();
+            BaseWriter.WritePropertyName(name);
+            BaseWriter.WriteValue(value);
+        }
+
+        public void WriteEndResponse()
+        {
+            ThrowIfDisposed();
+            BaseWriter.WriteEndObject();            
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if(BaseWriter == null)
+            {
+                throw new ObjectDisposedException(nameof(BaseWriter));
+            }
+        }
+
+        public void Dispose()
+        {
+            if(!_LeaveOpen)
+            {
+                BaseWriter?.Close();
+            }
+            BaseWriter = null;
+        }
+    }
+}

--- a/MoEmbed/Models/XmlResponseWriter.cs
+++ b/MoEmbed/Models/XmlResponseWriter.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Xml;
+
+namespace MoEmbed.Models
+{
+    public class XmlResponseWriter : IResponseWriter
+    {
+        private readonly bool _LeaveOpen;
+
+        public XmlResponseWriter(XmlWriter baseWriter, bool leaveOpen = false)
+        {
+            BaseWriter = baseWriter;
+            _LeaveOpen = leaveOpen;
+        }
+        protected XmlWriter BaseWriter { get; private set; }
+
+        public void WriteStartResponse()
+        {
+            ThrowIfDisposed();
+            BaseWriter.WriteStartElement("oembed");
+        }
+
+        public void WriteProperty(string name, bool value)
+            => WriteProperty(name, value ? "true": "false");
+
+        public void WriteProperty(string name, double value)
+            => WriteProperty(name, value.ToString("r"));
+        
+        public void WriteProperty(string name, object value)
+        {
+            ThrowIfDisposed();
+            if(value != null)
+            {
+                BaseWriter.WriteStartElement(name);
+                BaseWriter.WriteString(value.ToString());
+                BaseWriter.WriteEndElement(); 
+            }
+        }
+
+        public void WriteEndResponse()
+        {
+            ThrowIfDisposed();
+            BaseWriter.WriteEndElement();            
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if(BaseWriter == null)
+            {
+                throw new ObjectDisposedException(nameof(BaseWriter));
+            }
+        }
+
+        public void Dispose()
+        {
+            if(!_LeaveOpen)
+            {
+                BaseWriter?.Dispose();
+            }
+            BaseWriter = null;
+        }
+    }
+}


### PR DESCRIPTION
XMLをサポートする必要がある
↓
ルート要素が共通になるため、属性ベースの`XmlSerializer`は難しい
↓
共通の`IResponseWriter`を追加
↓
(`EmbedObject.Write`の引数を`IResponseWriter`に変更)