### PR TITLE
Substring by code point count in TwitterMetadata

### DIFF
--- a/MoEmbed.Twitter.Tests/TwitterMetadataProviderTest.cs
+++ b/MoEmbed.Twitter.Tests/TwitterMetadataProviderTest.cs
@@ -95,8 +95,10 @@ namespace MoEmbed.Providers
         }
 
         [Theory]
+        [InlineData("https://twitter.com/301kakugen/status/864532607916097536", "プリパラは好きぷり？ じゃあ大丈夫！できるぷり\n\n──南みれぃ")]
         [InlineData("https://mobile.twitter.com/4423s/status/901462528789626881", "")]
         [InlineData("https://twitter.com/EmmaKennedy/status/902886165350678529", "@realDonaldTrump You? Reading? IDON”TTHINKSO DonDon")]
+        [InlineData("https://twitter.com/KiraTwins/status/903283834669604864", "🍽")]
         public async void GetEmbedDataTest_Description(string uri, string desription)
         {
             var m = Assert.IsType<TwitterMetadata>(Provider.GetMetadata(new ConsumerRequest(new Uri(uri))));

--- a/MoEmbed.Twitter/TwitterMetadata.cs
+++ b/MoEmbed.Twitter/TwitterMetadata.cs
@@ -117,11 +117,24 @@ namespace MoEmbed.Models
 
             var authorName = HtmlEntity.DeEntitize($"{ user.Name }(@{ ScreenName })");
 
-            var description = tweet.FullText != null
-                                        && tweet.DisplayTextRange?.Length == 2
-                                            ? tweet.FullText.Substring(0, tweet.DisplayTextRange[1])
-                                : tweet.Prefix != null ? $"{tweet.Prefix} {tweet.Text}"
-                                : tweet.Text;
+            string description;
+            if (tweet.FullText != null
+                && tweet.DisplayTextRange?.Length == 2)
+            {
+                var length = tweet.DisplayTextRange[1];
+                for (var i = 0; i < length; i++)
+                {
+                    if (char.IsHighSurrogate(tweet.FullText[i]))
+                    {
+                        length++;
+                    }
+                }
+                description = tweet.FullText.Substring(0, length);
+            }
+            else
+            {
+                description = tweet.Prefix != null ? $"{tweet.Prefix} {tweet.Text}" : tweet.Text;
+            }
 
             Data = new EmbedData()
             {


### PR DESCRIPTION
netstandard1.6では`StringInfo.SubstringByTextElements`が使えないためこのようなクソコードになりました。