### PR TITLE
Fix Dockerfile to pass build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.2-sdk
+FROM microsoft/dotnet:2.2-sdk
 
 WORKDIR /usr/src/
 
@@ -8,9 +8,10 @@ COPY ./MoEmbed.App/MoEmbed.App.csproj         ./MoEmbed.App/MoEmbed.App.csproj
 COPY ./MoEmbed.Models/MoEmbed.Models.csproj   ./MoEmbed.Models/MoEmbed.Models.csproj
 COPY ./MoEmbed.Models.Tests/MoEmbed.Models.Tests.csproj   ./MoEmbed.Models.Tests/MoEmbed.Models.Tests.csproj
 COPY ./MoEmbed.Core/MoEmbed.Core.csproj       ./MoEmbed.Core/MoEmbed.Core.csproj
-COPY ./MoEmbed.Core.Tests/MoEmbed.Core.Tests.csproj     ./MoEmbed.Tests/MoEmbed.Core.Tests.csproj
+COPY ./MoEmbed.Core.Tests/MoEmbed.Core.Tests.csproj     ./MoEmbed.Core.Tests/MoEmbed.Core.Tests.csproj
 COPY ./MoEmbed.Twitter/MoEmbed.Twitter.csproj ./MoEmbed.Twitter/MoEmbed.Twitter.csproj
-COPY ./MoEmbed.Twitter.Tests/MoEmbed.Twitter.Tests.csproj     ./MoEmbed.Tests/MoEmbed.Twitter.Tests.csproj
+COPY ./MoEmbed.Twitter.Tests/MoEmbed.Twitter.Tests.csproj     ./MoEmbed.Twitter.Tests/MoEmbed.Twitter.Tests.csproj
+COPY ./MoEmbed.CodeGeneration/MoEmbed.CodeGeneration.csproj     ./MoEmbed.CodeGeneration/MoEmbed.CodeGeneration.csproj
 RUN dotnet restore
 
 # Copy entire source code
@@ -21,13 +22,14 @@ COPY ./MoEmbed.Core    ./MoEmbed.Core
 COPY ./MoEmbed.Core.Tests   ./MoEmbed.Core.Tests
 COPY ./MoEmbed.Twitter ./MoEmbed.Twitter
 COPY ./MoEmbed.Twitter.Tests   ./MoEmbed.Twitter.Tests
+COPY ./MoEmbed.CodeGeneration   ./MoEmbed.CodeGeneration
 
 # Build app
 WORKDIR /usr/src/MoEmbed.App
 RUN dotnet restore
 RUN dotnet publish -c Release -o out
 
-FROM microsoft/dotnet:1.1.2-runtime
+FROM microsoft/dotnet:2.2-runtime
 WORKDIR /usr/app
 COPY --from=0 /usr/src/MoEmbed.App/out/ .
 CMD dotnet ./MoEmbed.App.dll


### PR DESCRIPTION
dotnet2.1以降しかビルドできないっぽいのと、一部ファイルのコピーがミスってるようなので

log:

```
 ❯ docker build -t test --no-cache .                                                                                                                                                                                               [13:26:12]
[+] Building 60.2s (30/30) FINISHED                                                                                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     1.0s
 => => transferring dockerfile: 38B                                                                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.6s
 => => transferring context: 2B                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/microsoft/dotnet:2.2-sdk                                                                                                                                                                      1.9s 
 => [internal] load metadata for docker.io/microsoft/dotnet:2.2-runtime                                                                                                                                                                  1.8s
 => CACHED [stage-0 1/21] FROM docker.io/microsoft/dotnet:2.2-sdk@sha256:06c53fd178222eb693f78546303c850cc75174f8548c87210e7b83e3433603f5                                                                                                0.1s
 => CACHED [stage-1 1/2] FROM docker.io/microsoft/dotnet:2.2-runtime@sha256:cca439245c5d46d8549e83630c34f04dfbf3d6b70874e9a27faa971819df57a3                                                                                             0.0s 
 => CACHED [internal] helper image for file operations                                                                                                                                                                                   0.0s 
 => [internal] load build context                                                                                                                                                                                                        0.5s 
 => => transferring context: 7.95kB                                                                                                                                                                                                      0.0s
 => [stage-0 2/21] COPY ./MoEmbed.sln                            ./MoEmbed.sln                                                                                                                                                           2.8s
 => [stage-0 3/21] COPY ./MoEmbed.App/MoEmbed.App.csproj         ./MoEmbed.App/MoEmbed.App.csproj                                                                                                                                        2.7s
 => [stage-0 4/21] COPY ./MoEmbed.Models/MoEmbed.Models.csproj   ./MoEmbed.Models/MoEmbed.Models.csproj                                                                                                                                  2.3s
 => [stage-0 5/21] COPY ./MoEmbed.Models.Tests/MoEmbed.Models.Tests.csproj   ./MoEmbed.Models.Tests/MoEmbed.Models.Tests.csproj                                                                                                          2.4s
 => [stage-0 6/21] COPY ./MoEmbed.Core/MoEmbed.Core.csproj       ./MoEmbed.Core/MoEmbed.Core.csproj                                                                                                                                      2.0s
 => [stage-0 7/21] COPY ./MoEmbed.Core.Tests/MoEmbed.Core.Tests.csproj     ./MoEmbed.Core.Tests/MoEmbed.Core.Tests.csproj                                                                                                                0.7s
 => [stage-0 8/21] COPY ./MoEmbed.Twitter/MoEmbed.Twitter.csproj ./MoEmbed.Twitter/MoEmbed.Twitter.csproj                                                                                                                                1.4s
 => [stage-0 9/21] COPY ./MoEmbed.Twitter.Tests/MoEmbed.Twitter.Tests.csproj     ./MoEmbed.Twitter.Tests/MoEmbed.Twitter.Tests.csproj                                                                                                    1.5s
 => [stage-0 10/21] COPY ./MoEmbed.CodeGeneration/MoEmbed.CodeGeneration.csproj     ./MoEmbed.CodeGeneration/MoEmbed.CodeGeneration.csproj                                                                                               1.5s
 => [stage-0 11/21] RUN dotnet restore                                                                                                                                                                                                  22.5s
 => [stage-0 12/21] COPY ./MoEmbed.App     ./MoEmbed.App                                                                                                                                                                                 0.4s
 => [stage-0 13/21] COPY ./MoEmbed.Models  ./MoEmbed.Models                                                                                                                                                                              0.3s
 => [stage-0 14/21] COPY ./MoEmbed.Models.Tests  ./MoEmbed.Models.Tests                                                                                                                                                                  0.3s
 => [stage-0 15/21] COPY ./MoEmbed.Core    ./MoEmbed.Core                                                                                                                                                                                0.3s
 => [stage-0 16/21] COPY ./MoEmbed.Core.Tests   ./MoEmbed.Core.Tests                                                                                                                                                                     0.3s
 => [stage-0 17/21] COPY ./MoEmbed.Twitter ./MoEmbed.Twitter                                                                                                                                                                             0.3s
 => [stage-0 18/21] COPY ./MoEmbed.Twitter.Tests   ./MoEmbed.Twitter.Tests                                                                                                                                                               0.3s
 => [stage-0 19/21] COPY ./MoEmbed.CodeGeneration   ./MoEmbed.CodeGeneration                                                                                                                                                             0.3s
 => [stage-0 20/21] RUN dotnet restore                                                                                                                                                                                                   2.8s
 => [stage-0 21/21] RUN dotnet publish -c Release -o out                                                                                                                                                                                 8.8s
 => [stage-1 2/2] COPY --from=0 /usr/src/MoEmbed.App/out/ .                                                                                                                                                                              0.5s
 => exporting to image                                                                                                                                                                                                                   1.7s
 => => exporting layers                                                                                                                                                                                                                  1.3s
 => => writing image sha256:532c3886811d3ee3ca227aca9517555644dee3d4130930e40f952bb1e54d7ee4                                                                                                                                             0.1s
 => => naming to docker.io/library/test                                                                                                                                                                                                  0.1s
>>> elapsed time 1m2s
```