### PR TITLE
Add lacked StatusVisibility kind 

### DIFF
--- a/MoEmbed.Core/Models/Mastodon/StatusVisibility.cs
+++ b/MoEmbed.Core/Models/Mastodon/StatusVisibility.cs
@@ -24,6 +24,12 @@ namespace MoEmbed.Models.Mastodon
         /// The status is direct.
         /// </summary>
         [EnumMember(Value = "direct")]
-        Direct
+        Direct,
+
+        /// <summary>
+        /// The status is unlisted.
+        /// </summary>
+        [EnumMember(Value = "unlisted")]
+        Unlisted
     }
 }


### PR DESCRIPTION
`ttps://pawoo.net/@comicLO_YLNT/101736463953716598` （えっちな URL なので注意）形式の URL の展開に失敗していたので修正。


https://docs.joinmastodon.org/api/entities/#visibility

（mastodon の公式のドキュメントがどこかわからない…）