### PR TITLE
[WIP] Add TwitterExperimental Metadata and Provider

### DIFF
--- a/MoEmbed.Core/MetadataServiceCollectionExtensions.cs
+++ b/MoEmbed.Core/MetadataServiceCollectionExtensions.cs
@@ -30,9 +30,11 @@ namespace MoEmbed
             services.Add(new ServiceDescriptor(typeof(IMetadataProvider), typeof(DroplrMetadataProvider), ServiceLifetime.Singleton));
             services.Add(new ServiceDescriptor(typeof(IMetadataProvider), typeof(GyazoMetadataProvider), ServiceLifetime.Singleton));
             services.Add(new ServiceDescriptor(typeof(IMetadataProvider), typeof(MastodonMetadataProvider), ServiceLifetime.Singleton));
+            services.Add(new ServiceDescriptor(typeof(IMetadataProvider), typeof(TwitterExperimentalMetadataProvider), ServiceLifetime.Singleton));
 
             foreach (var t in OEmbedProxyMetadataProvider.CreateKnownHandlerTypes())
             {
+                if (t == typeof(TwitterMetadataProvider)) continue;
                 services.Add(new ServiceDescriptor(typeof(IMetadataProvider), t, ServiceLifetime.Singleton));
             }
 

--- a/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
+++ b/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
@@ -1,0 +1,96 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MoEmbed.Models.TweetExperimental;
+using Portable.Xaml.Markup;
+
+namespace MoEmbed.Models.Metadata
+{
+    /// <summary>
+    /// Represents the <see cref="Metadata" /> for the URL of the Twitter.
+    /// </summary>
+    [Serializable]
+    [ContentProperty(nameof(Data))]
+    public class TwitterExperimentalMetadata : Metadata
+    {
+        /// <summary>
+        /// Gets or sets the resolved data.
+        /// </summary>
+        [DefaultValue(null)]
+        public EmbedData Data { get; set; }
+
+        /// <summary>
+        /// Tweet url
+        /// </summary>
+        [DefaultValue(null)]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Twitter status id
+        /// </summary>
+        [DefaultValue(null)]
+        public string StatusId { get; set; }
+
+        /// <inheritdoc/>
+        public override async Task<EmbedData> FetchAsync(RequestContext context)
+        {
+            if (string.IsNullOrEmpty(StatusId)) return null;
+
+            var req = new HttpRequestMessage(HttpMethod.Get, $"https://cdn.syndication.twimg.com/tweet-result?id={StatusId}");
+            req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            var res = await context.Service.HttpClient.SendAsync(req).ConfigureAwait(false);
+
+            res.EnsureSuccessStatusCode();
+
+            var tweet = JsonSerializer.Deserialize<Tweet>(res.Content.ReadAsStream(), new JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+
+            return new EmbedData()
+            {
+                Url = Url,
+                MetadataImage = new Media
+                {
+                    Thumbnail = new ImageInfo
+                    {
+                        Url = tweet.User.ProfileImageUrlHttps,
+                        Height = 48,
+                        Width = 48,
+                    },
+                    RawUrl = tweet.User.ProfileImageUrlHttps,
+                    Location = Url,
+                    RestrictionPolicy = RestrictionPolicies.Safe
+                },
+                Title = tweet.User.Name,
+                Description = tweet.Text,
+                Medias = tweet.MediaDetails.Select(ToMedia).ToList(),
+                RestrictionPolicy = tweet.PossiblySensitive ? RestrictionPolicies.Restricted : RestrictionPolicies.Safe,
+
+                ProviderName = "Twitter",
+                ProviderUrl = "https://twitter.com/",
+            };
+        }
+
+        private static Media ToMedia(MediaDetail m) => new()
+        {
+            Type = MediaTypeFromString(m.Type),
+            Thumbnail = new()
+            {
+                Url = $"{m.MediaUrlHttps}:thumb",
+                Width = 150,
+                Height = 150,
+            },
+            RawUrl = m.MediaUrlHttps,
+            Location = m.ExpandedUrl,
+        };
+
+        private static MediaTypes MediaTypeFromString(string s) => s switch
+        {
+            "photo" => MediaTypes.Image,
+            "video" or "animated_gif" => MediaTypes.Video,
+            _ => throw new NotImplementedException()
+        };
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/BackgroundColor.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/BackgroundColor.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class BackgroundColor
+    {
+        [JsonPropertyName("red")]
+        public int Red { get; set; }
+
+        [JsonPropertyName("green")]
+        public int Green { get; set; }
+
+        [JsonPropertyName("blue")]
+        public int Blue { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/EditControl.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/EditControl.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class EditControl
+    {
+        [JsonPropertyName("edit_tweet_ids")]
+        public List<string> EditTweetIds { get; set; }
+
+        [JsonPropertyName("editable_until_msecs")]
+        public string EditableUntilMsecs { get; set; }
+
+        [JsonPropertyName("is_edit_eligible")]
+        public bool IsEditEligible { get; set; }
+
+        [JsonPropertyName("edits_remaining")]
+        public string EditsRemaining { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Entities.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Entities.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Entities
+    {
+        [JsonPropertyName("hashtags")]
+        public List<Hashtag> Hashtags { get; set; }
+
+        [JsonPropertyName("urls")]
+        public List<object> Urls { get; set; }
+
+        [JsonPropertyName("user_mentions")]
+        public List<UserMention> UserMentions { get; set; }
+
+        [JsonPropertyName("symbols")]
+        public List<object> Symbols { get; set; }
+
+        [JsonPropertyName("media")]
+        public List<Media> Media { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/ExtMediaAvailability.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/ExtMediaAvailability.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class ExtMediaAvailability
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Hashtag.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Hashtag.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Hashtag
+    {
+        [JsonPropertyName("indices")]
+        public List<int> Indices { get; set; }
+
+        [JsonPropertyName("text")]
+        public string Text { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Large.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Large.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Large
+    {
+        [JsonPropertyName("h")]
+        public int H { get; set; }
+
+        [JsonPropertyName("resize")]
+        public string Resize { get; set; }
+
+        [JsonPropertyName("w")]
+        public int W { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Media.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Media.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Media
+    {
+        [JsonPropertyName("display_url")]
+        public string DisplayUrl { get; set; }
+
+        [JsonPropertyName("expanded_url")]
+        public string ExpandedUrl { get; set; }
+
+        [JsonPropertyName("indices")]
+        public List<int> Indices { get; set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/MediaDetail.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/MediaDetail.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class MediaDetail
+    {
+        [JsonPropertyName("display_url")]
+        public string DisplayUrl { get; set; }
+
+        [JsonPropertyName("expanded_url")]
+        public string ExpandedUrl { get; set; }
+
+        [JsonPropertyName("ext_media_availability")]
+        public ExtMediaAvailability ExtMediaAvailability { get; set; }
+
+        [JsonPropertyName("indices")]
+        public List<int> Indices { get; set; }
+
+        [JsonPropertyName("media_url_https")]
+        public string MediaUrlHttps { get; set; }
+
+        [JsonPropertyName("original_info")]
+        public OriginalInfo OriginalInfo { get; set; }
+
+        [JsonPropertyName("sizes")]
+        public Sizes Sizes { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Medium.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Medium.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Medium
+    {
+        [JsonPropertyName("h")]
+        public int H { get; set; }
+
+        [JsonPropertyName("resize")]
+        public string Resize { get; set; }
+
+        [JsonPropertyName("w")]
+        public int W { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/OriginalInfo.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/OriginalInfo.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class OriginalInfo
+    {
+        [JsonPropertyName("height")]
+        public int Height { get; set; }
+
+        [JsonPropertyName("width")]
+        public int Width { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Photo.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Photo.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Photo
+    {
+        [JsonPropertyName("backgroundColor")]
+        public BackgroundColor BackgroundColor { get; set; }
+
+        [JsonPropertyName("cropCandidates")]
+        public List<object> CropCandidates { get; set; }
+
+        [JsonPropertyName("expandedUrl")]
+        public string ExpandedUrl { get; set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        [JsonPropertyName("width")]
+        public int Width { get; set; }
+
+        [JsonPropertyName("height")]
+        public int Height { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Sizes.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Sizes.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Sizes
+    {
+        [JsonPropertyName("large")]
+        public Large Large { get; set; }
+
+        [JsonPropertyName("medium")]
+        public Media Medium { get; set; }
+
+        [JsonPropertyName("small")]
+        public Small Small { get; set; }
+
+        [JsonPropertyName("thumb")]
+        public Thumb Thumb { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Small.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Small.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Small
+    {
+        [JsonPropertyName("h")]
+        public int H { get; set; }
+
+        [JsonPropertyName("resize")]
+        public string Resize { get; set; }
+
+        [JsonPropertyName("w")]
+        public int W { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Thumb.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Thumb.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Thumb
+    {
+        [JsonPropertyName("h")]
+        public int H { get; set; }
+
+        [JsonPropertyName("resize")]
+        public string Resize { get; set; }
+
+        [JsonPropertyName("w")]
+        public int W { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Tweet.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Tweet.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class Tweet
+    {
+        [JsonPropertyName("__typename")]
+        public string Typename { get; set; }
+
+        [JsonPropertyName("lang")]
+        public string Lang { get; set; }
+
+        [JsonPropertyName("favorite_count")]
+        public int FavoriteCount { get; set; }
+
+        [JsonPropertyName("possibly_sensitive")]
+        public bool PossiblySensitive { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonPropertyName("display_text_range")]
+        public List<int> DisplayTextRange { get; set; }
+
+        [JsonPropertyName("entities")]
+        public Entities Entities { get; set; }
+
+        [JsonPropertyName("id_str")]
+        public string IdStr { get; set; }
+
+        [JsonPropertyName("text")]
+        public string Text { get; set; }
+
+        [JsonPropertyName("user")]
+        public User User { get; set; }
+
+        [JsonPropertyName("edit_control")]
+        public EditControl EditControl { get; set; }
+
+        [JsonPropertyName("mediaDetails")]
+        public List<MediaDetail> MediaDetails { get; set; }
+
+        [JsonPropertyName("photos")]
+        public List<Photo> Photos { get; set; }
+
+        [JsonPropertyName("conversation_count")]
+        public int ConversationCount { get; set; }
+
+        [JsonPropertyName("news_action_type")]
+        public string NewsActionType { get; set; }
+
+        [JsonPropertyName("isEdited")]
+        public bool IsEdited { get; set; }
+
+        [JsonPropertyName("isStaleEdit")]
+        public bool IsStaleEdit { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/User.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/User.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class User
+    {
+        [JsonPropertyName("id_str")]
+        public string IdStr { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("profile_image_url_https")]
+        public string ProfileImageUrlHttps { get; set; }
+
+        [JsonPropertyName("screen_name")]
+        public string ScreenName { get; set; }
+
+        [JsonPropertyName("verified")]
+        public bool Verified { get; set; }
+
+        [JsonPropertyName("verified_type")]
+        public string VerifiedType { get; set; }
+
+        [JsonPropertyName("is_blue_verified")]
+        public bool IsBlueVerified { get; set; }
+
+        [JsonPropertyName("profile_image_shape")]
+        public string ProfileImageShape { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/UserMention.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/UserMention.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
+namespace MoEmbed.Models.TweetExperimental
+{
+    public class UserMention
+    {
+        [JsonPropertyName("id_str")]
+        public string IdStr { get; set; }
+
+        [JsonPropertyName("indices")]
+        public List<int> Indices { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("screen_name")]
+        public string ScreenName { get; set; }
+    }
+}

--- a/MoEmbed.Core/Providers/TwitterExperimentalMetadataProvider.cs
+++ b/MoEmbed.Core/Providers/TwitterExperimentalMetadataProvider.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using MoEmbed.Models;
+using MoEmbed.Models.Metadata;
+
+namespace MoEmbed.Providers
+{
+    /// <summary>
+    /// Provides a twitter.com specifiec metadata for the specified consumer request.
+    /// </summary>
+    public sealed class TwitterExperimentalMetadataProvider : IMetadataProvider
+    {
+        private const string GROUP_STATUS_ID = "statusId";
+        // private static readonly Regex uriPattern = new(@$"^(https://twitter\.com/|https://twitter\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+)|https://.*\.twitter\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+))");
+        private static readonly Regex uriPattern = new(@$"^(https://twitter\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+)|https://.*\.twitter\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+))");
+
+        bool IMetadataProvider.SupportsAnyHost
+            => false;
+
+        bool IMetadataProvider.IsEnabled
+            => true;
+
+        /// <inheritdoc/>
+        public bool CanHandle(ConsumerRequest request)
+            => uriPattern.IsMatch(request.Url.ToString());
+
+        /// <inheritdoc/>
+        public Metadata GetMetadata(ConsumerRequest request)
+        {
+            var m = uriPattern.Match(request.Url.ToString());
+            if (!m.Success)
+            {
+                return null;
+            }
+            return new TwitterExperimentalMetadata
+            {
+                Url = request.Url.ToString(),
+                StatusId = m.Groups[GROUP_STATUS_ID].Value,
+            };
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> GetSupportedHostNames()
+        {
+            yield return "twitter.com";
+        }
+    }
+}


### PR DESCRIPTION
#105

- [ ] test
- [ ] 設定による有効切り替え（ひとまず固定で本実装を有効にし oEmbed 実装は無効となるようにしてある）
- [ ] cache (必要かどうか)
- [ ] MoEmbed.Core\Models\TwitterExperimental\ 内の大量のプロパティに対するコメントが無い警告 `[CS1591]`
- [ ] https://twitter.com をハンドリングするか
  - 現在ハンドリングしておらずエラーとなる
  - API 実装時はハンドリングなし
  - oEmbed 実装はハンドリングしているがエラーとなっている
