### PR TITLE
Trivial fix

### DIFF
--- a/MoEmbed.Core.Tests/Models/Metadata/TwitterMetadataTest.cs
+++ b/MoEmbed.Core.Tests/Models/Metadata/TwitterMetadataTest.cs
@@ -11,7 +11,7 @@ namespace MoEmbed.Models.Metadata
         [Theory]
         [InlineData(
             463440424141459456L,
-            "US Department of the Interior",
+            "US Department of the Interior (@Interior)",
             "https://pbs.twimg.com/profile_images/432081479/DOI_LOGO_normal.jpg",
             "Sunsets don't get much better than this one over @GrandTetonNPS. #nature #sunset http://t.co/YuKy2rcjyU"
             )]

--- a/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
+++ b/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
@@ -1,4 +1,4 @@
-using MoEmbed.Models.TweetExperimental;
+using MoEmbed.Models.TwitterExperimental;
 
 using Portable.Xaml.Markup;
 

--- a/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
+++ b/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
@@ -46,6 +46,16 @@ namespace MoEmbed.Models.Metadata
             req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             var res = await context.Service.HttpClient.SendAsync(req).ConfigureAwait(false);
 
+            if (res.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                return new EmbedData()
+                {
+                    Url = Url,
+                    Title = "Not found",
+                    Description = "Sorry, we can't create an embed for that. It may have been deleted or made private. Please try again.",
+                };
+            }
+
             res.EnsureSuccessStatusCode();
 
             var tweet = JsonSerializer.Deserialize<Tweet>(res.Content.ReadAsStream(), new JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });

--- a/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
+++ b/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
@@ -65,7 +65,7 @@ namespace MoEmbed.Models.Metadata
                     Location = Url,
                     RestrictionPolicy = RestrictionPolicies.Safe
                 },
-                Title = tweet.User.Name,
+                Title = $"{tweet.User.Name} (@{tweet.User.ScreenName})",
                 Description = tweet.Text,
                 Medias = tweet.MediaDetails?.Select(ToMedia).ToList() ?? new(),
                 RestrictionPolicy = tweet.PossiblySensitive ? RestrictionPolicies.Restricted : RestrictionPolicies.Safe,

--- a/MoEmbed.Core/Models/TwitterExperimental/BackgroundColor.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/BackgroundColor.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class BackgroundColor
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/EditControl.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/EditControl.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class EditControl
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Entities.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Entities.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Entities
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/ExtMediaAvailability.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/ExtMediaAvailability.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class ExtMediaAvailability
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Hashtag.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Hashtag.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Hashtag
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Large.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Large.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Large
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Media.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Media.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Media
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/MediaDetail.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/MediaDetail.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class MediaDetail
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Medium.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Medium.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Medium
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/OriginalInfo.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/OriginalInfo.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class OriginalInfo
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Photo.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Photo.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Photo
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Sizes.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Sizes.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Sizes
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Small.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Small.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Small
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Thumb.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Thumb.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Thumb
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/Tweet.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Tweet.cs
@@ -2,8 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class Tweet
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/User.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/User.cs
@@ -1,7 +1,6 @@
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class User
     {

--- a/MoEmbed.Core/Models/TwitterExperimental/UserMention.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/UserMention.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-// Tweet myDeserializedClass = JsonConvert.DeserializeObject<Tweet>(myJsonResponse);
-namespace MoEmbed.Models.TweetExperimental
+namespace MoEmbed.Models.TwitterExperimental
 {
     public class UserMention
     {


### PR DESCRIPTION
#105 残作業

- Model の namespace 修正（ `TweetExperimental` → `TwitterExperimental`）
- `User name (@screenname)` の形式にする
- restricted tweet/search banned など展開できない場合のレスポンスを作成
