### PR TITLE
[TwitterExperimental] Add token parameter, UA, referrer

### DIFF
--- a/MoEmbed.Core.Tests/Models/Metadata/TwitterExperimentalMetadataTest.cs
+++ b/MoEmbed.Core.Tests/Models/Metadata/TwitterExperimentalMetadataTest.cs
@@ -12,7 +12,7 @@ namespace MoEmbed.Models.Metadata
         [InlineData(
             463440424141459456L,
             "US Department of the Interior",
-            "Sunsets don't get much better than this one over @GrandTetonNPS. #nature #sunset pic.twitter.com/YuKy2rcjyU"
+            "Sunsets don't get much better than this one over @GrandTetonNPS. #nature #sunset http://t.co/YuKy2rcjyU"
             )]
         public void FetchAsyncTest(long tweetId, string expectedDisplayName, string expectedDescription)
         {

--- a/MoEmbed.Core.Tests/Models/Metadata/TwitterMetadataTest.cs
+++ b/MoEmbed.Core.Tests/Models/Metadata/TwitterMetadataTest.cs
@@ -34,13 +34,13 @@ namespace MoEmbed.Models.Metadata
 
         [Theory]
         [InlineData(
-            463440424141459456L,
-            "https://twitter.com/Interior/status/463440424141459456/photo/1",
-            "https://pbs.twimg.com/media/Bm54nBCCYAACwBi.jpg"
+            1608046425149177856L,
+            "https://twitter.com/supermomonga/status/1608046425149177856/photo/1",
+            "https://pbs.twimg.com/media/FlDtq9fakAIHeKj.jpg"
             )]
         public void SingleImageTest(long tweetId, string expectedLocation, string expectedRawUrl)
         {
-            var uri = $"https://twitter.com/Interior/status/{tweetId}";
+            var uri = $"https://twitter.com/supermomonga/status/{tweetId}";
             var target = new TwitterExperimentalMetadataProvider().GetMetadata(
                 new ConsumerRequest(new Uri(uri)));
 

--- a/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
+++ b/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
@@ -42,8 +42,11 @@ namespace MoEmbed.Models.Metadata
         {
             if (string.IsNullOrEmpty(StatusId)) return null;
 
-            var req = new HttpRequestMessage(HttpMethod.Get, $"https://cdn.syndication.twimg.com/tweet-result?id={StatusId}");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"https://cdn.syndication.twimg.com/tweet-result?id={StatusId}&lang=en&token=elonmusk");
             req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            req.Headers.UserAgent.Clear();
+            req.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36");
+            req.Headers.Referrer = new("https://platform.twitter.com/");
             var res = await context.Service.HttpClient.SendAsync(req).ConfigureAwait(false);
 
             if (res.StatusCode == System.Net.HttpStatusCode.NotFound)

--- a/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
+++ b/MoEmbed.Core/Models/Metadata/TwitterExperimentalMetadata.cs
@@ -42,7 +42,7 @@ namespace MoEmbed.Models.Metadata
         {
             if (string.IsNullOrEmpty(StatusId)) return null;
 
-            var req = new HttpRequestMessage(HttpMethod.Get, $"https://cdn.syndication.twimg.com/tweet-result?id={StatusId}&lang=en&token=elonmusk");
+            var req = new HttpRequestMessage(HttpMethod.Get, $"https://cdn.syndication.twimg.com/tweet-result?id={StatusId}&lang=ja&token=elonmusk");
             req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             req.Headers.UserAgent.Clear();
             req.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36");
@@ -63,28 +63,37 @@ namespace MoEmbed.Models.Metadata
 
             var tweet = JsonSerializer.Deserialize<Tweet>(res.Content.ReadAsStream(), new JsonSerializerOptions { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
 
-            return new EmbedData()
+            return tweet.Typename switch
             {
-                Url = Url,
-                MetadataImage = new Media
+                "TweetTombstone" => new EmbedData()
                 {
-                    Thumbnail = new ImageInfo
-                    {
-                        Url = tweet.User.ProfileImageUrlHttps,
-                        Height = 48,
-                        Width = 48,
-                    },
-                    RawUrl = tweet.User.ProfileImageUrlHttps,
-                    Location = Url,
-                    RestrictionPolicy = RestrictionPolicies.Safe
+                    Url = Url,
+                    Title = "Twitter",
+                    Description = tweet.Tombstone.Text.TextText,
                 },
-                Title = $"{tweet.User.Name} (@{tweet.User.ScreenName})",
-                Description = tweet.Text,
-                Medias = tweet.MediaDetails?.Select(ToMedia).ToList() ?? new(),
-                RestrictionPolicy = tweet.PossiblySensitive ? RestrictionPolicies.Restricted : RestrictionPolicies.Safe,
+                _ => new EmbedData()
+                {
+                    Url = Url,
+                    MetadataImage = new Media
+                    {
+                        Thumbnail = new ImageInfo
+                        {
+                            Url = tweet.User.ProfileImageUrlHttps,
+                            Height = 48,
+                            Width = 48,
+                        },
+                        RawUrl = tweet.User.ProfileImageUrlHttps,
+                        Location = Url,
+                        RestrictionPolicy = RestrictionPolicies.Safe
+                    },
+                    Title = $"{tweet.User.Name} (@{tweet.User.ScreenName})",
+                    Description = tweet.Text,
+                    Medias = tweet.MediaDetails?.Select(ToMedia).ToList() ?? new(),
+                    RestrictionPolicy = tweet.PossiblySensitive ? RestrictionPolicies.Restricted : RestrictionPolicies.Safe,
 
-                ProviderName = "Twitter",
-                ProviderUrl = "https://twitter.com/",
+                    ProviderName = "Twitter",
+                    ProviderUrl = "https://twitter.com/",
+                },
             };
         }
 

--- a/MoEmbed.Core/Models/TwitterExperimental/Entity.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Entity.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TwitterExperimental
+{
+    public class Entity
+    {
+        [JsonPropertyName("from_index")]
+        public long FromIndex { get; set; }
+
+        [JsonPropertyName("to_index")]
+        public long ToIndex { get; set; }
+
+        [JsonPropertyName("ref")]
+        public Ref Ref { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Ref.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Ref.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TwitterExperimental
+{
+    public class Ref
+    {
+        [JsonPropertyName("__typename")]
+        public string Typename { get; set; }
+
+        [JsonPropertyName("url")]
+        public Uri Url { get; set; }
+
+        [JsonPropertyName("url_type")]
+        public string UrlType { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Text.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Text.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TwitterExperimental
+{
+    public class Text
+    {
+        [JsonPropertyName("text")]
+        public string TextText { get; set; }
+
+        [JsonPropertyName("entities")]
+        public Entity[] Entities { get; set; }
+
+        [JsonPropertyName("rtl")]
+        public bool Rtl { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Tombstone.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Tombstone.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace MoEmbed.Models.TwitterExperimental
+{
+    public class Tombstone
+    {
+        [JsonPropertyName("text")]
+        public Text Text { get; set; }
+    }
+}

--- a/MoEmbed.Core/Models/TwitterExperimental/Tweet.cs
+++ b/MoEmbed.Core/Models/TwitterExperimental/Tweet.cs
@@ -56,5 +56,8 @@ namespace MoEmbed.Models.TwitterExperimental
 
         [JsonPropertyName("isStaleEdit")]
         public bool IsStaleEdit { get; set; }
+
+        [JsonPropertyName("tombstone")]
+        public Tombstone Tombstone { get; set; }
     }
 }


### PR DESCRIPTION
token ってパラメータに任意の文字列（実際は `token=43pviq9hetr` といった形式のツイート毎の固有文字列っぽい）を指定するとひとまずレスポンスは返ってくるようになった。
それとは別に Age-Restricted なコンテンツは 404 ではなくその旨のレスポンスが返るようになったようなので別途調整が必要。