### PR TITLE
Support x.com with TwitterExperimentalMetadataProvider

### DIFF
--- a/MoEmbed.Core.Tests/Models/Metadata/TwitterMetadataTest.cs
+++ b/MoEmbed.Core.Tests/Models/Metadata/TwitterMetadataTest.cs
@@ -54,5 +54,28 @@ namespace MoEmbed.Models.Metadata
             Assert.Equal(expectedLocation, data.Medias[0].Location);
             Assert.Equal(expectedRawUrl, data.Medias[0].RawUrl);
         }
+        [Theory]
+        [InlineData(
+                463440424141459456L,
+                "US Department of the Interior (@Interior)",
+                "https://pbs.twimg.com/profile_images/432081479/DOI_LOGO_normal.jpg",
+                "Sunsets don't get much better than this one over @GrandTetonNPS. #nature #sunset http://t.co/YuKy2rcjyU"
+                )]
+        public void XComFetchAsyncTest(long tweetId, string expectedDisplayName, string expectedProfileImageUrl, string expectedDescription)
+        {
+            var uri = $"https://x.com/Interior/status/{tweetId}";
+            var target = new TwitterExperimentalMetadataProvider().GetMetadata(
+                new ConsumerRequest(new Uri(uri)));
+
+            var data = target.FetchAsync(
+                            new RequestContext(
+                                new MetadataService(),
+                                new ConsumerRequest(new Uri(uri))))
+                                .GetAwaiter().GetResult();
+
+            Assert.Equal(expectedDisplayName, data.Title);
+            Assert.Equal(expectedProfileImageUrl, data.MetadataImage.Thumbnail.Url);
+            Assert.Equal(expectedDescription, data.Description);
+        }
     }
 }

--- a/MoEmbed.Core/MetadataServiceCollectionExtensions.cs
+++ b/MoEmbed.Core/MetadataServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System.Linq;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using MoEmbed.Providers;
@@ -11,6 +12,11 @@ namespace MoEmbed
     /// </summary>
     public static class MetadataServiceCollectionExtensions
     {
+        static System.Type[] IgnoredMetadataProvierTypes = {
+            typeof(TwitterMetadataProvider),
+            typeof(XMetadataProvider),
+        };
+
         /// <summary>
         /// Adds <see cref="ServiceDescriptor" /> s of the <see cref="IMetadataProvider" /> in the
         /// <see cref="N:MoEmbed.Providers" /> namespace to the specified <see
@@ -34,7 +40,7 @@ namespace MoEmbed
 
             foreach (var t in OEmbedProxyMetadataProvider.CreateKnownHandlerTypes())
             {
-                if (t == typeof(TwitterMetadataProvider)) continue;
+                if (IgnoredMetadataProvierTypes.Contains(t)) continue;
                 services.Add(new ServiceDescriptor(typeof(IMetadataProvider), t, ServiceLifetime.Singleton));
             }
 

--- a/MoEmbed.Core/Providers/TwitterExperimentalMetadataProvider.cs
+++ b/MoEmbed.Core/Providers/TwitterExperimentalMetadataProvider.cs
@@ -12,7 +12,7 @@ namespace MoEmbed.Providers
     {
         private const string GROUP_STATUS_ID = "statusId";
         // private static readonly Regex uriPattern = new(@$"^(https://twitter\.com/|https://twitter\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+)|https://.*\.twitter\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+))");
-        private static readonly Regex uriPattern = new(@$"^(https://twitter\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+)|https://.*\.twitter\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+))");
+        private static readonly Regex uriPattern = new(@$"^(https://(?:twitter|x)\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+)|https://.*\.(?:twitter|x)\.com/.*/status/(?<{GROUP_STATUS_ID}>\d+))");
 
         bool IMetadataProvider.SupportsAnyHost
             => false;
@@ -43,6 +43,7 @@ namespace MoEmbed.Providers
         public IEnumerable<string> GetSupportedHostNames()
         {
             yield return "twitter.com";
+            yield return "x.com";
         }
     }
 }


### PR DESCRIPTION
x.com ドメインを `OEmbedProxyMetadataProvider` の対象から外し `TwitterExperimentalMetadataProvider` で処理するようにした。