### PR TITLE
Add workflow to auto-update oembed submodule

### DIFF
--- a/.github/workflows/update-oembed-submodule.yaml
+++ b/.github/workflows/update-oembed-submodule.yaml
@@ -1,0 +1,56 @@
+name: Update oembed submodule
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # 毎週月曜 9:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-submodule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Update oembed submodule
+        run: git submodule update --remote oembed
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Regenerate oEmbed proxy providers
+        run: dotnet run --project MoEmbed.CodeGeneration
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.check.outputs.changed == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automated/update-oembed-submodule
+          commit-message: "Update oembed submodule"
+          title: "Update oembed submodule"
+          body: |
+            Automated update of the `oembed` submodule to the latest commit and regeneration of oEmbed proxy providers.
+          delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated'
+        run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- oembedサブモジュールを週次(毎週月曜)で自動更新するGitHub Actionsワークフローを追加
- サブモジュール更新後にoEmbedプロキシプロバイダーのコード生成も実行
- CIが通ったら自動マージ(squash)

## Test plan
- [ ] workflow_dispatchで手動実行して動作確認