### PR TITLE
fix: use rollForward in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
     "version": "10.0.104"
+    "rollForward": "latestFeature"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.104"
+    "version": "10.0.104",
     "rollForward": "latestFeature"
   },
   "test": {


### PR DESCRIPTION
## Description
When Docker build, It failed.
Use `rollForward` in global.json.

## Log
```
#18 [build 10/11] RUN dotnet restore --locked-mode
#18 0.049 The command could not be loaded, possibly because:
#18 0.049   * You intended to execute a .NET application:
#18 0.049       The application 'restore' does not exist or is not a managed .dll or .exe.
#18 0.049   * You intended to execute a .NET SDK command:
#18 0.049       A compatible .NET SDK was not found.
#18 0.049
#18 0.049 Requested SDK version: 10.0.104
#18 0.049 global.json file: /src/global.json
#18 0.049
#18 0.049 Installed SDKs:
#18 0.049
#18 0.049 Install the [10.0.104] .NET SDK or update [/src/global.json] to match an installed SDK.
#18 0.049
#18 0.049 Learn about SDK resolution:
#18 0.049 https://aka.ms/dotnet/sdk-not-found
#18 0.049 10.0.201 [/usr/share/dotnet/sdk]
#18 ERROR: process "/bin/sh -c dotnet restore --locked-mode" did not complete successfully: exit code: 155

> [build 10/11] RUN dotnet restore --locked-mode:
0.049 Requested SDK version: 10.0.104
0.049 global.json file: /src/global.json
0.049
0.049 Installed SDKs:
0.049
0.049 Install the [10.0.104] .NET SDK or update [/src/global.json] to match an installed SDK.
0.049
0.049 Learn about SDK resolution:
0.049 https://aka.ms/dotnet/sdk-not-found
0.049 10.0.201 [/usr/share/dotnet/sdk] 
```